### PR TITLE
Dockerfile and github action to build it into an image

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,24 @@
+name: Build docker image
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Publish Image
+      uses: matootie/github-docker@v3.1.0
+      with:
+        accessToken: ${{ github.token }}
+        tag: |
+          latest
+          ${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# The builder image, used to build the virtual environment
+FROM python:3.11 AS builder
+
+RUN pip install poetry==1.8.4
+
+ENV POETRY_NO_INTERACTION=1 \
+    POETRY_VIRTUALENVS_IN_PROJECT=1 \
+    POETRY_VIRTUALENVS_CREATE=1 \
+    POETRY_CACHE_DIR=/tmp/poetry_cache
+
+WORKDIR /app
+
+COPY pyproject.toml poetry.lock ./
+
+COPY art_graph ./art_graph
+
+RUN touch README.md
+
+RUN poetry install # --no-root && rm -rf $POETRY_CACHE_DIR
+
+# The runtime image, used to just run the code provided its virtual environment
+FROM python:3.11-slim AS runtime
+
+WORKDIR /app
+
+ENV VIRTUAL_ENV=/app/.venv \
+    PATH="/app/.venv/bin:$PATH"
+
+COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+
+COPY art_graph ./art_graph
+COPY scripts ./scripts
+

--- a/README.md
+++ b/README.md
@@ -8,6 +8,38 @@ creates an annotated graph whose nodes are people and works of art. Examples of 
 - Music, and the musicians, composers, and producers who create it
 - Open source software projects and their contributors
 
+## Docker
+
+Build the image:
+
+```
+DOCKER_BUILDKIT=1 docker build --target=runtime -f Dockerfile . -t artist-graph
+```
+
+Run the image with a shell:
+
+```
+docker run --name artist-graph -v /some/host/machine/directory:/app/data/:rw -it artist-graph sh
+```
+
+Remove the container:
+
+```
+docker container rm artist-graph
+```
+
+Download the IMDb data:
+
+```
+docker run --name artist-graph -v /some/host/machine/directory/:/app/data/:rw -it artist-graph python scripts/imdb_download.py
+```
+
+Build the SQLite database:
+
+```
+docker run --name artist-graph -v /some/host/machine/directory/:/app/data/:rw -it artist-graph python scripts/s3_2db.py
+```
+
 ## Acknowledgements
 
 This project began with code originally part of the [Cinema Game](https://github.com/ChiPowers/cinema_game) project,


### PR DESCRIPTION
Dockerfile and github action that will build it into an image.

Docker image can be build locally by running:

```
DOCKER_BUILDKIT=1 docker build --target=runtime -f Dockerfile . -t artist-graph
```

To run the imdb dataset download using a folder from the host machine to store the dataset:

```
docker run --name artist-graph -v /some/host/machine/directory/:/app/data/:rw -it artist-graph python scripts/imdb_download.py
```

To run the sqlite import using a folder from the host machine for dataset and db file storage:

```
docker run --name artist-graph -v /some/host/machine/directory/:/app/data/:rw -it artist-graph python scripts/s3_2db.py
```