### PR TITLE
Cache actor and movie data

### DIFF
--- a/art_graph/cinema_data_providers/cache/cached_client.py
+++ b/art_graph/cinema_data_providers/cache/cached_client.py
@@ -1,0 +1,97 @@
+"""A TMDb client that caches results in a local SQLite database."""
+
+from typing import List, Optional
+
+from sqlalchemy import Engine
+from sqlalchemy.orm import Session
+
+from ..tmdb.client import TMDbClient
+from ..tmdb.config import TMDbConfig
+from ..tmdb_models import CastMember, Movie, MovieCreditRole, Person
+from .db import create_tables, get_engine
+from .operations import (
+    get_cached_movie_cast,
+    get_cached_person_movies,
+    store_movie_cast,
+    store_person_movies,
+)
+
+
+class CachedTMDbClient(TMDbClient):
+    def __init__(self, config: TMDbConfig, engine: Optional[Engine] = None):
+        super().__init__(config)
+        self.engine = engine or get_engine()
+        create_tables(self.engine)
+
+    async def get_person_movies(
+        self, person_id: int, limit: int = 20
+    ) -> List[MovieCreditRole]:
+        with Session(bind=self.engine) as session:
+            cached = get_cached_person_movies(session, person_id)
+            if cached is not None and len(cached) > 0:
+                results = []
+                for credit in cached:
+                    movie = credit.movie
+                    results.append(
+                        MovieCreditRole(
+                            id=movie.tmdb_id,
+                            title=movie.title,
+                            release_date=movie.release_date,
+                            poster_path=movie.poster_path,
+                            popularity=movie.popularity,
+                            character=credit.character,
+                            order=credit.credit_order,
+                        )
+                    )
+                results.sort(key=lambda m: m.popularity, reverse=True)
+                return results[:limit]
+
+        # Cache miss — call the API
+        movies = await super().get_person_movies(person_id, limit=limit)
+
+        # We need the person record to store; fetch details if needed
+        person = await self.search_person_by_id(person_id)
+        if person is not None:
+            with Session(bind=self.engine) as session:
+                store_person_movies(session, person, movies)
+
+        return movies
+
+    async def get_movie_cast(self, movie_id: int) -> List[CastMember]:
+        with Session(bind=self.engine) as session:
+            cached = get_cached_movie_cast(session, movie_id)
+            if cached is not None and len(cached) > 0:
+                return [
+                    CastMember(
+                        id=credit.person.tmdb_id,
+                        name=credit.person.name,
+                        profile_path=credit.person.profile_path,
+                        popularity=credit.person.popularity,
+                        character=credit.character,
+                        order=credit.credit_order,
+                    )
+                    for credit in cached
+                ]
+
+        # Cache miss — call the API
+        cast = await super().get_movie_cast(movie_id)
+
+        # We need the movie record to store; fetch via search
+        movie = await self.search_movie_by_id(movie_id)
+        if movie is not None:
+            with Session(bind=self.engine) as session:
+                store_movie_cast(session, movie, cast)
+
+        return cast
+
+    async def search_person_by_id(self, person_id: int) -> Optional[Person]:
+        """Get person details by ID, used to populate cache records."""
+        return await self.get_person_details(person_id)
+
+    async def search_movie_by_id(self, movie_id: int) -> Optional[Movie]:
+        """Get movie details by ID, used to populate cache records."""
+        try:
+            data = await self._get(f"/movie/{movie_id}")
+            return Movie(**data)
+        except Exception:
+            return None

--- a/art_graph/cinema_data_providers/cache/db.py
+++ b/art_graph/cinema_data_providers/cache/db.py
@@ -1,0 +1,22 @@
+import sqlalchemy
+from sqlalchemy.orm import Session
+
+from art_graph import directories
+from .orm_models import Base
+
+
+def db_path(db_filename="tmdb_cache.db") -> str:
+    return directories.data(db_filename)
+
+
+def get_engine(db_filename="tmdb_cache.db") -> sqlalchemy.Engine:
+    absolute_path = db_path(db_filename=db_filename)
+    return sqlalchemy.create_engine(f"sqlite:///{absolute_path}")
+
+
+def create_tables(engine: sqlalchemy.Engine):
+    Base.metadata.create_all(bind=engine)
+
+
+def get_session(engine: sqlalchemy.Engine) -> Session:
+    return Session(bind=engine)

--- a/art_graph/cinema_data_providers/cache/operations.py
+++ b/art_graph/cinema_data_providers/cache/operations.py
@@ -1,0 +1,161 @@
+"""Read/write operations for the TMDb cache.
+
+All writes are upserts — if a person or movie already exists, their record is
+updated with the latest data.
+"""
+
+from typing import List, Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .orm_models import PersonRecord, MovieRecord, CreditRecord
+from ..tmdb_models import (
+    CastMember,
+    MovieCreditRole,
+    Person,
+    Movie,
+)
+
+
+# ---------------------------------------------------------------------------
+# Write helpers
+# ---------------------------------------------------------------------------
+
+
+def upsert_person(session: Session, person_id: int, name: str, **kwargs):
+    record = session.get(PersonRecord, person_id)
+    if record is None:
+        record = PersonRecord(tmdb_id=person_id, name=name, **kwargs)
+        session.add(record)
+    else:
+        record.name = name
+        for key, value in kwargs.items():
+            setattr(record, key, value)
+    return record
+
+
+def upsert_movie(session: Session, movie_id: int, title: str, **kwargs):
+    record = session.get(MovieRecord, movie_id)
+    if record is None:
+        record = MovieRecord(tmdb_id=movie_id, title=title, **kwargs)
+        session.add(record)
+    else:
+        record.title = title
+        for key, value in kwargs.items():
+            setattr(record, key, value)
+    return record
+
+
+def upsert_credit(
+    session: Session,
+    person_id: int,
+    movie_id: int,
+    character: Optional[str] = None,
+    credit_order: Optional[int] = None,
+):
+    stmt = select(CreditRecord).where(
+        CreditRecord.person_id == person_id,
+        CreditRecord.movie_id == movie_id,
+    )
+    record = session.execute(stmt).scalar_one_or_none()
+    if record is None:
+        record = CreditRecord(
+            person_id=person_id,
+            movie_id=movie_id,
+            character=character,
+            credit_order=credit_order,
+        )
+        session.add(record)
+    else:
+        record.character = character
+        record.credit_order = credit_order
+    return record
+
+
+# ---------------------------------------------------------------------------
+# Store API responses
+# ---------------------------------------------------------------------------
+
+
+def store_person_movies(
+    session: Session, person: Person, movies: List[MovieCreditRole]
+):
+    """Cache a person and their filmography (from get_person_movies)."""
+    upsert_person(
+        session,
+        person.id,
+        person.name,
+        profile_path=person.profile_path,
+        popularity=person.popularity,
+    )
+    for movie in movies:
+        upsert_movie(
+            session,
+            movie.id,
+            movie.title,
+            release_date=movie.release_date,
+            poster_path=movie.poster_path,
+            popularity=movie.popularity,
+        )
+        upsert_credit(
+            session,
+            person_id=person.id,
+            movie_id=movie.id,
+            character=movie.character,
+            credit_order=movie.order,
+        )
+    session.commit()
+
+
+def store_movie_cast(session: Session, movie: Movie, cast: List[CastMember]):
+    """Cache a movie and its cast (from get_movie_cast)."""
+    upsert_movie(
+        session,
+        movie.id,
+        movie.title,
+        release_date=movie.release_date,
+        poster_path=movie.poster_path,
+        popularity=movie.popularity,
+    )
+    for member in cast:
+        upsert_person(
+            session,
+            member.id,
+            member.name,
+            profile_path=member.profile_path,
+            popularity=member.popularity,
+        )
+        upsert_credit(
+            session,
+            person_id=member.id,
+            movie_id=movie.id,
+            character=member.character,
+            credit_order=member.order,
+        )
+    session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Read helpers
+# ---------------------------------------------------------------------------
+
+
+def get_cached_person_movies(
+    session: Session, person_id: int
+) -> Optional[List[CreditRecord]]:
+    """Return cached credits for a person, or None if the person isn't cached."""
+    person = session.get(PersonRecord, person_id)
+    if person is None:
+        return None
+    return person.credits
+
+
+def get_cached_movie_cast(
+    session: Session, movie_id: int
+) -> Optional[List[CreditRecord]]:
+    """Return cached credits for a movie, or None if the movie isn't cached."""
+    movie = session.get(MovieRecord, movie_id)
+    if movie is None:
+        return None
+    return movie.credits

--- a/art_graph/cinema_data_providers/cache/orm_models.py
+++ b/art_graph/cinema_data_providers/cache/orm_models.py
@@ -1,0 +1,44 @@
+from sqlalchemy import Column, Integer, String, Float, Date, ForeignKey
+from sqlalchemy.orm import DeclarativeBase, relationship
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class PersonRecord(Base):
+    __tablename__ = "person"
+
+    tmdb_id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    profile_path = Column(String, nullable=True)
+    popularity = Column(Float, default=0.0)
+
+    credits = relationship("CreditRecord", back_populates="person")
+
+
+class MovieRecord(Base):
+    __tablename__ = "movie"
+
+    tmdb_id = Column(Integer, primary_key=True)
+    title = Column(String, nullable=False)
+    release_date = Column(Date, nullable=True)
+    poster_path = Column(String, nullable=True)
+    popularity = Column(Float, default=0.0)
+
+    credits = relationship("CreditRecord", back_populates="movie")
+
+
+class CreditRecord(Base):
+    __tablename__ = "credit"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    person_id = Column(
+        Integer, ForeignKey("person.tmdb_id"), nullable=False, index=True
+    )
+    movie_id = Column(Integer, ForeignKey("movie.tmdb_id"), nullable=False, index=True)
+    character = Column(String, nullable=True)
+    credit_order = Column(Integer, nullable=True)
+
+    person = relationship("PersonRecord", back_populates="credits")
+    movie = relationship("MovieRecord", back_populates="credits")

--- a/art_graph/cinema_data_providers/tmdb_models.py
+++ b/art_graph/cinema_data_providers/tmdb_models.py
@@ -90,11 +90,17 @@ class Movie(BaseModel):
 
     @property
     def poster_url(self) -> Optional[str]:
-        return f"{DEFAULT_TMDB_IMAGE_BASE}{self.poster_path}" if self.poster_path else None
+        return (
+            f"{DEFAULT_TMDB_IMAGE_BASE}{self.poster_path}" if self.poster_path else None
+        )
 
     @property
     def backdrop_url(self) -> Optional[str]:
-        return f"{DEFAULT_TMDB_BACKDROP_BASE}{self.backdrop_path}" if self.backdrop_path else None
+        return (
+            f"{DEFAULT_TMDB_BACKDROP_BASE}{self.backdrop_path}"
+            if self.backdrop_path
+            else None
+        )
 
 
 class Person(BaseModel):
@@ -116,7 +122,11 @@ class Person(BaseModel):
 
     @property
     def profile_url(self) -> Optional[str]:
-        return f"{DEFAULT_TMDB_IMAGE_BASE}{self.profile_path}" if self.profile_path else None
+        return (
+            f"{DEFAULT_TMDB_IMAGE_BASE}{self.profile_path}"
+            if self.profile_path
+            else None
+        )
 
 
 class MovieSearchResults(BaseModel):

--- a/art_graph/tests/test_cache_operations.py
+++ b/art_graph/tests/test_cache_operations.py
@@ -1,0 +1,209 @@
+from datetime import date
+
+import sqlalchemy
+from sqlalchemy.orm import Session
+
+from art_graph.cinema_data_providers.cache.orm_models import (
+    Base,
+    PersonRecord,
+    MovieRecord,
+)
+from art_graph.cinema_data_providers.cache.operations import (
+    upsert_person,
+    upsert_movie,
+    upsert_credit,
+    store_person_movies,
+    store_movie_cast,
+    get_cached_person_movies,
+    get_cached_movie_cast,
+)
+from art_graph.cinema_data_providers.tmdb_models import (
+    CastMember,
+    MovieCreditRole,
+    Person,
+    Movie,
+)
+
+
+def in_memory_engine():
+    engine = sqlalchemy.create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    return engine
+
+
+class TestUpsert:
+    def test_upsert_person_insert(self):
+        engine = in_memory_engine()
+        with Session(bind=engine) as session:
+            upsert_person(session, 6193, "Leonardo DiCaprio", popularity=80.0)
+            session.commit()
+
+        with Session(bind=engine) as session:
+            person = session.get(PersonRecord, 6193)
+            assert person.name == "Leonardo DiCaprio"
+            assert person.popularity == 80.0
+
+    def test_upsert_person_update(self):
+        engine = in_memory_engine()
+        with Session(bind=engine) as session:
+            upsert_person(session, 6193, "Leonardo DiCaprio", popularity=80.0)
+            session.commit()
+
+        with Session(bind=engine) as session:
+            upsert_person(session, 6193, "Leonardo DiCaprio", popularity=85.0)
+            session.commit()
+
+        with Session(bind=engine) as session:
+            person = session.get(PersonRecord, 6193)
+            assert person.popularity == 85.0
+
+    def test_upsert_movie_insert(self):
+        engine = in_memory_engine()
+        with Session(bind=engine) as session:
+            upsert_movie(session, 27205, "Inception", release_date=date(2010, 7, 16))
+            session.commit()
+
+        with Session(bind=engine) as session:
+            movie = session.get(MovieRecord, 27205)
+            assert movie.title == "Inception"
+            assert movie.release_date == date(2010, 7, 16)
+
+    def test_upsert_movie_update(self):
+        engine = in_memory_engine()
+        with Session(bind=engine) as session:
+            upsert_movie(session, 27205, "Inception", popularity=80.0)
+            session.commit()
+
+        with Session(bind=engine) as session:
+            upsert_movie(session, 27205, "Inception", popularity=90.0)
+            session.commit()
+
+        with Session(bind=engine) as session:
+            movie = session.get(MovieRecord, 27205)
+            assert movie.popularity == 90.0
+
+    def test_upsert_credit_insert(self):
+        engine = in_memory_engine()
+        with Session(bind=engine) as session:
+            upsert_person(session, 6193, "Leonardo DiCaprio")
+            upsert_movie(session, 27205, "Inception")
+            upsert_credit(session, 6193, 27205, character="Cobb", credit_order=0)
+            session.commit()
+
+        with Session(bind=engine) as session:
+            credits = get_cached_movie_cast(session, 27205)
+            assert len(credits) == 1
+            assert credits[0].character == "Cobb"
+
+    def test_upsert_credit_update(self):
+        engine = in_memory_engine()
+        with Session(bind=engine) as session:
+            upsert_person(session, 6193, "Leonardo DiCaprio")
+            upsert_movie(session, 27205, "Inception")
+            upsert_credit(session, 6193, 27205, character="Cobb", credit_order=0)
+            session.commit()
+
+        with Session(bind=engine) as session:
+            upsert_credit(session, 6193, 27205, character="Dom Cobb", credit_order=0)
+            session.commit()
+
+        with Session(bind=engine) as session:
+            credits = get_cached_movie_cast(session, 27205)
+            assert len(credits) == 1
+            assert credits[0].character == "Dom Cobb"
+
+
+class TestStorePersonMovies:
+    def test_stores_person_and_movies(self):
+        engine = in_memory_engine()
+        person = Person(id=6193, name="Leonardo DiCaprio", popularity=80.0)
+        movies = [
+            MovieCreditRole(
+                id=27205,
+                title="Inception",
+                release_date=date(2010, 7, 16),
+                popularity=90.0,
+                character="Cobb",
+                order=0,
+            ),
+            MovieCreditRole(
+                id=597,
+                title="Titanic",
+                release_date=date(1997, 12, 19),
+                popularity=85.0,
+                character="Jack Dawson",
+                order=0,
+            ),
+        ]
+
+        with Session(bind=engine) as session:
+            store_person_movies(session, person, movies)
+
+        with Session(bind=engine) as session:
+            cached = get_cached_person_movies(session, 6193)
+            assert len(cached) == 2
+            titles = {c.movie.title for c in cached}
+            assert titles == {"Inception", "Titanic"}
+
+    def test_returns_none_for_uncached_person(self):
+        engine = in_memory_engine()
+        with Session(bind=engine) as session:
+            assert get_cached_person_movies(session, 9999) is None
+
+
+class TestStoreMovieCast:
+    def test_stores_movie_and_cast(self):
+        engine = in_memory_engine()
+        movie = Movie(id=27205, title="Inception", release_date=date(2010, 7, 16))
+        cast = [
+            CastMember(id=6193, name="Leonardo DiCaprio", character="Cobb", order=0),
+            CastMember(
+                id=24045, name="Joseph Gordon-Levitt", character="Arthur", order=1
+            ),
+        ]
+
+        with Session(bind=engine) as session:
+            store_movie_cast(session, movie, cast)
+
+        with Session(bind=engine) as session:
+            cached = get_cached_movie_cast(session, 27205)
+            assert len(cached) == 2
+            names = {c.person.name for c in cached}
+            assert names == {"Leonardo DiCaprio", "Joseph Gordon-Levitt"}
+
+    def test_returns_none_for_uncached_movie(self):
+        engine = in_memory_engine()
+        with Session(bind=engine) as session:
+            assert get_cached_movie_cast(session, 9999) is None
+
+
+class TestOverlappingData:
+    def test_shared_movie_across_two_people(self):
+        """Two actors in the same movie — the movie record should be shared."""
+        engine = in_memory_engine()
+        person_a = Person(id=6193, name="Leonardo DiCaprio")
+        person_b = Person(id=24045, name="Joseph Gordon-Levitt")
+        inception_a = MovieCreditRole(
+            id=27205,
+            title="Inception",
+            character="Cobb",
+            order=0,
+        )
+        inception_b = MovieCreditRole(
+            id=27205,
+            title="Inception",
+            character="Arthur",
+            order=1,
+        )
+
+        with Session(bind=engine) as session:
+            store_person_movies(session, person_a, [inception_a])
+            store_person_movies(session, person_b, [inception_b])
+
+        with Session(bind=engine) as session:
+            cast = get_cached_movie_cast(session, 27205)
+            assert len(cast) == 2
+
+            person_a_movies = get_cached_person_movies(session, 6193)
+            assert len(person_a_movies) == 1
+            assert person_a_movies[0].character == "Cobb"

--- a/art_graph/tests/test_cache_orm.py
+++ b/art_graph/tests/test_cache_orm.py
@@ -1,0 +1,148 @@
+from datetime import date
+
+import sqlalchemy
+from sqlalchemy.orm import Session
+
+from art_graph.cinema_data_providers.cache.orm_models import (
+    Base,
+    PersonRecord,
+    MovieRecord,
+    CreditRecord,
+)
+
+
+def in_memory_engine():
+    engine = sqlalchemy.create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    return engine
+
+
+class TestTableCreation:
+    def test_tables_exist(self):
+        engine = in_memory_engine()
+        inspector = sqlalchemy.inspect(engine)
+        table_names = inspector.get_table_names()
+        assert "person" in table_names
+        assert "movie" in table_names
+        assert "credit" in table_names
+
+    def test_person_columns(self):
+        engine = in_memory_engine()
+        inspector = sqlalchemy.inspect(engine)
+        columns = {c["name"] for c in inspector.get_columns("person")}
+        assert columns == {"tmdb_id", "name", "profile_path", "popularity"}
+
+    def test_movie_columns(self):
+        engine = in_memory_engine()
+        inspector = sqlalchemy.inspect(engine)
+        columns = {c["name"] for c in inspector.get_columns("movie")}
+        assert columns == {
+            "tmdb_id",
+            "title",
+            "release_date",
+            "poster_path",
+            "popularity",
+        }
+
+    def test_credit_columns(self):
+        engine = in_memory_engine()
+        inspector = sqlalchemy.inspect(engine)
+        columns = {c["name"] for c in inspector.get_columns("credit")}
+        assert columns == {"id", "person_id", "movie_id", "character", "credit_order"}
+
+
+class TestRoundTrip:
+    def test_insert_and_read_person(self):
+        engine = in_memory_engine()
+        with Session(bind=engine) as session:
+            session.add(
+                PersonRecord(tmdb_id=6193, name="Leonardo DiCaprio", popularity=80.0)
+            )
+            session.commit()
+
+        with Session(bind=engine) as session:
+            person = session.get(PersonRecord, 6193)
+            assert person.name == "Leonardo DiCaprio"
+            assert person.popularity == 80.0
+
+    def test_insert_and_read_movie(self):
+        engine = in_memory_engine()
+        with Session(bind=engine) as session:
+            session.add(
+                MovieRecord(
+                    tmdb_id=27205,
+                    title="Inception",
+                    release_date=date(2010, 7, 16),
+                    popularity=90.0,
+                )
+            )
+            session.commit()
+
+        with Session(bind=engine) as session:
+            movie = session.get(MovieRecord, 27205)
+            assert movie.title == "Inception"
+            assert movie.release_date == date(2010, 7, 16)
+
+    def test_insert_and_read_credit(self):
+        engine = in_memory_engine()
+        with Session(bind=engine) as session:
+            session.add(PersonRecord(tmdb_id=6193, name="Leonardo DiCaprio"))
+            session.add(MovieRecord(tmdb_id=27205, title="Inception"))
+            session.add(
+                CreditRecord(
+                    person_id=6193,
+                    movie_id=27205,
+                    character="Cobb",
+                    credit_order=0,
+                )
+            )
+            session.commit()
+
+        with Session(bind=engine) as session:
+            credit = session.query(CreditRecord).first()
+            assert credit.character == "Cobb"
+            assert credit.credit_order == 0
+            assert credit.person.name == "Leonardo DiCaprio"
+            assert credit.movie.title == "Inception"
+
+    def test_person_credits_relationship(self):
+        engine = in_memory_engine()
+        with Session(bind=engine) as session:
+            session.add(PersonRecord(tmdb_id=6193, name="Leonardo DiCaprio"))
+            session.add(MovieRecord(tmdb_id=27205, title="Inception"))
+            session.add(MovieRecord(tmdb_id=597, title="Titanic"))
+            session.add(CreditRecord(person_id=6193, movie_id=27205, character="Cobb"))
+            session.add(
+                CreditRecord(person_id=6193, movie_id=597, character="Jack Dawson")
+            )
+            session.commit()
+
+        with Session(bind=engine) as session:
+            person = session.get(PersonRecord, 6193)
+            assert len(person.credits) == 2
+            titles = {c.movie.title for c in person.credits}
+            assert titles == {"Inception", "Titanic"}
+
+    def test_movie_credits_relationship(self):
+        engine = in_memory_engine()
+        with Session(bind=engine) as session:
+            session.add(PersonRecord(tmdb_id=6193, name="Leonardo DiCaprio"))
+            session.add(PersonRecord(tmdb_id=24045, name="Joseph Gordon-Levitt"))
+            session.add(MovieRecord(tmdb_id=27205, title="Inception"))
+            session.add(
+                CreditRecord(
+                    person_id=6193, movie_id=27205, character="Cobb", credit_order=0
+                )
+            )
+            session.add(
+                CreditRecord(
+                    person_id=24045, movie_id=27205, character="Arthur", credit_order=1
+                )
+            )
+            session.commit()
+
+        with Session(bind=engine) as session:
+            movie = session.get(MovieRecord, 27205)
+            assert len(movie.credits) == 2
+            names = {c.person.name for c in movie.credits}
+            assert names == {"Leonardo DiCaprio", "Joseph Gordon-Levitt"}

--- a/art_graph/tests/test_cached_client.py
+++ b/art_graph/tests/test_cached_client.py
@@ -1,0 +1,208 @@
+"""Tests for CachedTMDbClient — verifies cache hit/miss behavior.
+
+Uses an in-memory SQLite DB and patches the parent TMDbClient API methods
+so no real HTTP calls are made.
+"""
+
+from datetime import date
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import sqlalchemy
+
+from art_graph.cinema_data_providers.cache.cached_client import CachedTMDbClient
+from art_graph.cinema_data_providers.cache.orm_models import Base
+from art_graph.cinema_data_providers.tmdb.config import TMDbConfig
+from art_graph.cinema_data_providers.tmdb_models import (
+    CastMember,
+    Movie,
+    MovieCreditRole,
+    Person,
+)
+
+
+@pytest.fixture
+def engine():
+    eng = sqlalchemy.create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=eng)
+    return eng
+
+
+@pytest.fixture
+def config():
+    return TMDbConfig(api_key="test-key")
+
+
+@pytest.fixture
+def client(config, engine):
+    return CachedTMDbClient(config, engine=engine)
+
+
+PERSON = Person(id=6193, name="Leonardo DiCaprio", popularity=80.0)
+MOVIES = [
+    MovieCreditRole(
+        id=27205,
+        title="Inception",
+        release_date=date(2010, 7, 16),
+        popularity=90.0,
+        character="Cobb",
+        order=0,
+    ),
+    MovieCreditRole(
+        id=597,
+        title="Titanic",
+        release_date=date(1997, 12, 19),
+        popularity=85.0,
+        character="Jack Dawson",
+        order=0,
+    ),
+]
+
+MOVIE = Movie(
+    id=27205, title="Inception", release_date=date(2010, 7, 16), popularity=90.0
+)
+CAST = [
+    CastMember(
+        id=6193, name="Leonardo DiCaprio", character="Cobb", order=0, popularity=80.0
+    ),
+    CastMember(
+        id=24045,
+        name="Joseph Gordon-Levitt",
+        character="Arthur",
+        order=1,
+        popularity=50.0,
+    ),
+]
+
+
+class TestGetPersonMovies:
+    @pytest.mark.asyncio
+    async def test_cache_miss_calls_api(self, client):
+        with (
+            patch.object(
+                client.__class__.__bases__[0],
+                "get_person_movies",
+                new_callable=AsyncMock,
+                return_value=MOVIES,
+            ) as mock_api,
+            patch.object(
+                client,
+                "get_person_details",
+                new_callable=AsyncMock,
+                return_value=PERSON,
+            ),
+        ):
+            result = await client.get_person_movies(6193)
+            mock_api.assert_called_once_with(6193, limit=20)
+            assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_api(self, client):
+        # Populate cache
+        with (
+            patch.object(
+                client.__class__.__bases__[0],
+                "get_person_movies",
+                new_callable=AsyncMock,
+                return_value=MOVIES,
+            ),
+            patch.object(
+                client,
+                "get_person_details",
+                new_callable=AsyncMock,
+                return_value=PERSON,
+            ),
+        ):
+            await client.get_person_movies(6193)
+
+        # Second call should hit cache
+        with patch.object(
+            client.__class__.__bases__[0],
+            "get_person_movies",
+            new_callable=AsyncMock,
+        ) as mock_api:
+            result = await client.get_person_movies(6193)
+            mock_api.assert_not_called()
+            assert len(result) == 2
+            titles = {m.title for m in result}
+            assert titles == {"Inception", "Titanic"}
+
+    @pytest.mark.asyncio
+    async def test_cached_results_sorted_by_popularity(self, client):
+        with (
+            patch.object(
+                client.__class__.__bases__[0],
+                "get_person_movies",
+                new_callable=AsyncMock,
+                return_value=MOVIES,
+            ),
+            patch.object(
+                client,
+                "get_person_details",
+                new_callable=AsyncMock,
+                return_value=PERSON,
+            ),
+        ):
+            await client.get_person_movies(6193)
+
+        with patch.object(
+            client.__class__.__bases__[0],
+            "get_person_movies",
+            new_callable=AsyncMock,
+        ):
+            result = await client.get_person_movies(6193)
+            assert result[0].title == "Inception"  # popularity 90
+            assert result[1].title == "Titanic"  # popularity 85
+
+
+class TestGetMovieCast:
+    @pytest.mark.asyncio
+    async def test_cache_miss_calls_api(self, client):
+        with (
+            patch.object(
+                client.__class__.__bases__[0],
+                "get_movie_cast",
+                new_callable=AsyncMock,
+                return_value=CAST,
+            ) as mock_api,
+            patch.object(
+                client,
+                "search_movie_by_id",
+                new_callable=AsyncMock,
+                return_value=MOVIE,
+            ),
+        ):
+            result = await client.get_movie_cast(27205)
+            mock_api.assert_called_once_with(27205)
+            assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_api(self, client):
+        # Populate cache
+        with (
+            patch.object(
+                client.__class__.__bases__[0],
+                "get_movie_cast",
+                new_callable=AsyncMock,
+                return_value=CAST,
+            ),
+            patch.object(
+                client,
+                "search_movie_by_id",
+                new_callable=AsyncMock,
+                return_value=MOVIE,
+            ),
+        ):
+            await client.get_movie_cast(27205)
+
+        # Second call should hit cache
+        with patch.object(
+            client.__class__.__bases__[0],
+            "get_movie_cast",
+            new_callable=AsyncMock,
+        ) as mock_api:
+            result = await client.get_movie_cast(27205)
+            mock_api.assert_not_called()
+            assert len(result) == 2
+            names = {c.name for c in result}
+            assert names == {"Leonardo DiCaprio", "Joseph Gordon-Levitt"}

--- a/poetry.lock
+++ b/poetry.lock
@@ -901,6 +901,80 @@ files = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.4.0"
+description = "Lightweight in-process concurrent programming"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""
+files = [
+    {file = "greenlet-3.4.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:d18eae9a7fb0f499efcd146b8c9750a2e1f6e0e93b5a382b3481875354a430e6"},
+    {file = "greenlet-3.4.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:636d2f95c309e35f650e421c23297d5011716be15d966e6328b367c9fc513a82"},
+    {file = "greenlet-3.4.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:234582c20af9742583c3b2ddfbdbb58a756cfff803763ffaae1ac7990a9fac31"},
+    {file = "greenlet-3.4.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ac6a5f618be581e1e0713aecec8e54093c235e5fa17d6d8eb7ffc487e2300508"},
+    {file = "greenlet-3.4.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:523677e69cd4711b5a014e37bc1fb3a29947c3e3a5bb6a527e1cc50312e5a398"},
+    {file = "greenlet-3.4.0-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:d336d46878e486de7d9458653c722875547ac8d36a1cff9ffaf4a74a3c1f62eb"},
+    {file = "greenlet-3.4.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b45e45fe47a19051a396abb22e19e7836a59ee6c5a90f3be427343c37908d65b"},
+    {file = "greenlet-3.4.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5434271357be07f3ad0936c312645853b7e689e679e29310e2de09a9ea6c3adf"},
+    {file = "greenlet-3.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:a19093fbad824ed7c0f355b5ff4214bffda5f1a7f35f29b31fcaa240cc0135ab"},
+    {file = "greenlet-3.4.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:805bebb4945094acbab757d34d6e1098be6de8966009ab9ca54f06ff492def58"},
+    {file = "greenlet-3.4.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:439fc2f12b9b512d9dfa681c5afe5f6b3232c708d13e6f02c845e0d9f4c2d8c6"},
+    {file = "greenlet-3.4.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a70ed1cb0295bee1df57b63bf7f46b4e56a5c93709eea769c1fec1bb23a95875"},
+    {file = "greenlet-3.4.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c5696c42e6bb5cfb7c6ff4453789081c66b9b91f061e5e9367fa15792644e76"},
+    {file = "greenlet-3.4.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c660bce1940a1acae5f51f0a064f1bc785d07ea16efcb4bc708090afc4d69e83"},
+    {file = "greenlet-3.4.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:89995ce5ddcd2896d89615116dd39b9703bfa0c07b583b85b89bf1b5d6eddf81"},
+    {file = "greenlet-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ee407d4d1ca9dc632265aee1c8732c4a2d60adff848057cdebfe5fe94eb2c8a2"},
+    {file = "greenlet-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:956215d5e355fffa7c021d168728321fd4d31fd730ac609b1653b450f6a4bc71"},
+    {file = "greenlet-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:5cb614ace7c27571270354e9c9f696554d073f8aa9319079dcba466bbdead711"},
+    {file = "greenlet-3.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:04403ac74fe295a361f650818de93be11b5038a78f49ccfb64d3b1be8fbf1267"},
+    {file = "greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a"},
+    {file = "greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97"},
+    {file = "greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996"},
+    {file = "greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d"},
+    {file = "greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc"},
+    {file = "greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077"},
+    {file = "greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de"},
+    {file = "greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08"},
+    {file = "greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2"},
+    {file = "greenlet-3.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:f38b81880ba28f232f1f675893a39cf7b6db25b31cc0a09bb50787ecf957e85e"},
+    {file = "greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1"},
+    {file = "greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1"},
+    {file = "greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82"},
+    {file = "greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f"},
+    {file = "greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf"},
+    {file = "greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55"},
+    {file = "greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729"},
+    {file = "greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c"},
+    {file = "greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940"},
+    {file = "greenlet-3.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:9390ad88b652b1903814eaabd629ca184db15e0eeb6fe8a390bbf8b9106ae15a"},
+    {file = "greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e"},
+    {file = "greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d"},
+    {file = "greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615"},
+    {file = "greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19"},
+    {file = "greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf"},
+    {file = "greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd"},
+    {file = "greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf"},
+    {file = "greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda"},
+    {file = "greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d"},
+    {file = "greenlet-3.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:f8296d4e2b92af34ebde81085a01690f26a51eb9ac09a0fcadb331eb36dbc802"},
+    {file = "greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece"},
+    {file = "greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8"},
+    {file = "greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2"},
+    {file = "greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa"},
+    {file = "greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed"},
+    {file = "greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72"},
+    {file = "greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f"},
+    {file = "greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a"},
+    {file = "greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705"},
+    {file = "greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff"},
+]
+
+[package.extras]
+docs = ["Sphinx", "furo"]
+test = ["objgraph", "psutil", "setuptools"]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -3351,6 +3425,108 @@ files = [
 ]
 
 [[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+description = "Database Abstraction Library"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "sqlalchemy-2.0.49-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:42e8804962f9e6f4be2cbaedc0c3718f08f60a16910fa3d86da5a1e3b1bfe60f"},
+    {file = "sqlalchemy-2.0.49-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc992c6ed024c8c3c592c5fc9846a03dd68a425674900c70122c77ea16c5fb0b"},
+    {file = "sqlalchemy-2.0.49-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6eb188b84269f357669b62cb576b5b918de10fb7c728a005fa0ebb0b758adce1"},
+    {file = "sqlalchemy-2.0.49-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:62557958002b69699bdb7f5137c6714ca1133f045f97b3903964f47db97ea339"},
+    {file = "sqlalchemy-2.0.49-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:da9b91bca419dc9b9267ffadde24eae9b1a6bffcd09d0a207e5e3af99a03ce0d"},
+    {file = "sqlalchemy-2.0.49-cp310-cp310-win32.whl", hash = "sha256:5e61abbec255be7b122aa461021daa7c3f310f3e743411a67079f9b3cc91ece3"},
+    {file = "sqlalchemy-2.0.49-cp310-cp310-win_amd64.whl", hash = "sha256:0c98c59075b890df8abfcc6ad632879540f5791c68baebacb4f833713b510e75"},
+    {file = "sqlalchemy-2.0.49-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c5070135e1b7409c4161133aa525419b0062088ed77c92b1da95366ec5cbebbe"},
+    {file = "sqlalchemy-2.0.49-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ac7a3e245fd0310fd31495eb61af772e637bdf7d88ee81e7f10a3f271bff014"},
+    {file = "sqlalchemy-2.0.49-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d4e5a0ceba319942fa6b585cf82539288a61e314ef006c1209f734551ab9536"},
+    {file = "sqlalchemy-2.0.49-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3ddcb27fb39171de36e207600116ac9dfd4ae46f86c82a9bf3934043e80ebb88"},
+    {file = "sqlalchemy-2.0.49-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:32fe6a41ad97302db2931f05bb91abbcc65b5ce4c675cd44b972428dd2947700"},
+    {file = "sqlalchemy-2.0.49-cp311-cp311-win32.whl", hash = "sha256:46d51518d53edfbe0563662c96954dc8fcace9832332b914375f45a99b77cc9a"},
+    {file = "sqlalchemy-2.0.49-cp311-cp311-win_amd64.whl", hash = "sha256:951d4a210744813be63019f3df343bf233b7432aadf0db54c75802247330d3af"},
+    {file = "sqlalchemy-2.0.49-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbccb45260e4ff1b7db0be80a9025bb1e6698bdb808b83fff0000f7a90b2c0b"},
+    {file = "sqlalchemy-2.0.49-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb37f15714ec2652d574f021d479e78cd4eb9d04396dca36568fdfffb3487982"},
+    {file = "sqlalchemy-2.0.49-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3bb9ec6436a820a4c006aad1ac351f12de2f2dbdaad171692ee457a02429b672"},
+    {file = "sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8d6efc136f44a7e8bc8088507eaabbb8c2b55b3dbb63fe102c690da0ddebe55e"},
+    {file = "sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e06e617e3d4fd9e51d385dfe45b077a41e9d1b033a7702551e3278ac597dc750"},
+    {file = "sqlalchemy-2.0.49-cp312-cp312-win32.whl", hash = "sha256:83101a6930332b87653886c01d1ee7e294b1fe46a07dd9a2d2b4f91bcc88eec0"},
+    {file = "sqlalchemy-2.0.49-cp312-cp312-win_amd64.whl", hash = "sha256:618a308215b6cececb6240b9abde545e3acdabac7ae3e1d4e666896bf5ba44b4"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d"},
+    {file = "sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158"},
+    {file = "sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7"},
+    {file = "sqlalchemy-2.0.49-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8a97ac839c2c6672c4865e48f3cbad7152cee85f4233fb4ca6291d775b9b954a"},
+    {file = "sqlalchemy-2.0.49-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c338ec6ec01c0bc8e735c58b9f5d51e75bacb6ff23296658826d7cfdfdb8678a"},
+    {file = "sqlalchemy-2.0.49-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:566df36fd0e901625523a5a1835032f1ebdd7f7886c54584143fa6c668b4df3b"},
+    {file = "sqlalchemy-2.0.49-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:d99945830a6f3e9638d89a28ed130b1eb24c91255e4f24366fbe699b983f29e4"},
+    {file = "sqlalchemy-2.0.49-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:01146546d84185f12721a1d2ce0c6673451a7894d1460b592d378ca4871a0c72"},
+    {file = "sqlalchemy-2.0.49-cp38-cp38-win32.whl", hash = "sha256:69469ce8ce7a8df4d37620e3163b71238719e1e2e5048d114a1b6ce0fbf8c662"},
+    {file = "sqlalchemy-2.0.49-cp38-cp38-win_amd64.whl", hash = "sha256:b95b2f470c1b2683febd2e7eab1d3f0e078c91dbdd0b00e9c645d07a413bb99f"},
+    {file = "sqlalchemy-2.0.49-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:43d044780732d9e0381ac8d5316f95d7f02ef04d6e4ef6dc82379f09795d993f"},
+    {file = "sqlalchemy-2.0.49-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d6be30b2a75362325176c036d7fb8d19e8846c77e87683ffaa8177b35135613"},
+    {file = "sqlalchemy-2.0.49-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d898cc2c76c135ef65517f4ddd7a3512fb41f23087b0650efb3418b8389a3cd1"},
+    {file = "sqlalchemy-2.0.49-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:059d7151fff513c53a4638da8778be7fce81a0c4854c7348ebd0c4078ddf28fe"},
+    {file = "sqlalchemy-2.0.49-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:334edbcff10514ad1d66e3a70b339c0a29886394892490119dbb669627b17717"},
+    {file = "sqlalchemy-2.0.49-cp39-cp39-win32.whl", hash = "sha256:74ab4ee7794d7ed1b0c37e7333640e0f0a626fc7b398c07a7aef52f484fddde3"},
+    {file = "sqlalchemy-2.0.49-cp39-cp39-win_amd64.whl", hash = "sha256:88690f4e1f0fbf5339bedbb127e240fec1fd3070e9934c0b7bef83432f779d2f"},
+    {file = "sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0"},
+    {file = "sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f"},
+]
+
+[package.dependencies]
+greenlet = {version = ">=1", markers = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""}
+typing-extensions = ">=4.6.0"
+
+[package.extras]
+aiomysql = ["aiomysql (>=0.2.0)", "greenlet (>=1)"]
+aioodbc = ["aioodbc", "greenlet (>=1)"]
+aiosqlite = ["aiosqlite", "greenlet (>=1)", "typing_extensions (!=3.10.0.1)"]
+asyncio = ["greenlet (>=1)"]
+asyncmy = ["asyncmy (>=0.2.3,!=0.2.4,!=0.2.6)", "greenlet (>=1)"]
+mariadb-connector = ["mariadb (>=1.0.1,!=1.1.2,!=1.1.5,!=1.1.10)"]
+mssql = ["pyodbc"]
+mssql-pymssql = ["pymssql"]
+mssql-pyodbc = ["pyodbc"]
+mypy = ["mypy (>=0.910)"]
+mysql = ["mysqlclient (>=1.4.0)"]
+mysql-connector = ["mysql-connector-python"]
+oracle = ["cx_oracle (>=8)"]
+oracle-oracledb = ["oracledb (>=1.0.1)"]
+postgresql = ["psycopg2 (>=2.7)"]
+postgresql-asyncpg = ["asyncpg", "greenlet (>=1)"]
+postgresql-pg8000 = ["pg8000 (>=1.29.1)"]
+postgresql-psycopg = ["psycopg (>=3.0.7)"]
+postgresql-psycopg2binary = ["psycopg2-binary"]
+postgresql-psycopg2cffi = ["psycopg2cffi"]
+postgresql-psycopgbinary = ["psycopg[binary] (>=3.0.7)"]
+pymysql = ["pymysql"]
+sqlcipher = ["sqlcipher3_binary"]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 description = "Extract data from python stack frames and tracebacks for informative displays"
@@ -3610,4 +3786,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "e23cba602d0efec49065c3b42065151aa26e718786fc9d9c3e4f300055cb0c6a"
+content-hash = "293ebf421cb320ef2f5c6200af929f7ceae33de2ab19a1e2589b5ef5d545f30f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "art_graph"
-version = "0.2.2"
+version = "0.2.3"
 description = "Tools for creating and analyzing art graphs"
 authors = ["Reuben Brasher <rkbrasher@gmail.com>"]
 license = "MIT"
@@ -18,6 +18,7 @@ tqdm = "^4.66.4"
 pydantic = "^2.7.3"
 psycopg2-binary = "^2.9.9"
 httpx = "^0.27.0"
+sqlalchemy = "^2.0.49"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
  - Add SQLAlchemy-backed TMDb cache with three tables: `person`, `movie`, `credit` 
  - Implement upsert operations and cache read/write functions that work with       
  existing TMDb pydantic models                                                     
  - Add `CachedTMDbClient` that extends `TMDbClient` with transparent cache-on-read
  behavior                                                                          
  - Cinema_game can switch to cached client with a one-line change in 
  `tools/tmdb.py`                                                                   
                  
  ## Details

  ### Schema (`cache/orm_models.py`)
  - `PersonRecord` — tmdb_id, name, profile_path, popularity
  - `MovieRecord` — tmdb_id, title, release_date, poster_path, popularity           
  - `CreditRecord` — person_id (FK), movie_id (FK), character, credit_order
                                                                                    
  ### Cache operations (`cache/operations.py`)                                      
  - Upsert helpers for all three tables (insert or update)
  - `store_person_movies()` / `store_movie_cast()` — persist API responses          
  - `get_cached_person_movies()` / `get_cached_movie_cast()` — check cache, return
  `None` on miss                                                                    
   
  ### Cached client (`cache/cached_client.py`)                                      
  - Subclasses `TMDbClient`, overrides `get_person_movies` and `get_movie_cast`
  - On cache hit: returns cached data without API call
  - On cache miss: calls API, writes through to cache, returns result               
  - SQLite DB file (`data/tmdb_cache.db`) is already covered by `.gitignore`
                                                                                    
  ## Test plan    

  - [ ] 9 ORM tests: table creation, column inspection, round-trip CRUD,            
  relationships
  - [ ] 11 operations tests: upsert insert/update, store/retrieve filmographies and 
  casts, overlapping data
  - [ ] 5 cached client tests: cache miss calls API, cache hit skips API, sort order
   preserved                                                                        
  - [ ] Full suite: 58 tests passing, no regressions
