### PR TITLE
TMBb client calls have option to trust cache or not

### DIFF
--- a/art_graph/cinema_data_providers/cache/cached_client.py
+++ b/art_graph/cinema_data_providers/cache/cached_client.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 from ..tmdb.client import TMDbClient
 from ..tmdb.config import TMDbConfig
 from ..tmdb_models import CastMember, Movie, MovieCreditRole, Person
-from .orm_models import Base
+from .orm_models import Base, PersonRecord, MovieRecord
 from .operations import (
     get_cached_movie_cast,
     get_cached_person_movies,
@@ -28,32 +28,31 @@ class CachedTMDbClient(TMDbClient):
         Base.metadata.create_all(bind=engine)
 
     async def get_person_movies(
-        self, person_id: int, limit: int = 20
+        self, person_id: int, limit: int = 20, trust_cache: bool = False
     ) -> List[MovieCreditRole]:
-        with Session(bind=self.engine) as session:
-            cached = get_cached_person_movies(session, person_id)
-            if cached is not None and len(cached) > 0:
-                results = []
-                for credit in cached:
-                    movie = credit.movie
-                    results.append(
-                        MovieCreditRole(
-                            id=movie.tmdb_id,
-                            title=movie.title,
-                            release_date=movie.release_date,
-                            poster_path=movie.poster_path,
-                            popularity=movie.popularity,
-                            character=credit.character,
-                            order=credit.credit_order,
-                        )
-                    )
-                results.sort(key=lambda m: m.popularity, reverse=True)
-                return results[:limit]
+        if trust_cache:
+            with Session(bind=self.engine) as session:
+                person = session.get(PersonRecord, person_id)
+                if person is not None and person.has_full_filmography:
+                    cached = get_cached_person_movies(session, person_id)
+                    if cached:
+                        results = [
+                            MovieCreditRole(
+                                id=credit.movie.tmdb_id,
+                                title=credit.movie.title,
+                                release_date=credit.movie.release_date,
+                                poster_path=credit.movie.poster_path,
+                                popularity=credit.movie.popularity,
+                                character=credit.character,
+                                order=credit.credit_order,
+                            )
+                            for credit in cached
+                        ]
+                        results.sort(key=lambda m: m.popularity, reverse=True)
+                        return results[:limit]
 
-        # Cache miss — call the API
         movies = await super().get_person_movies(person_id, limit=limit)
 
-        # We need the person record to store; fetch details if needed
         person = await self.search_person_by_id(person_id)
         if person is not None:
             with Session(bind=self.engine) as session:
@@ -61,26 +60,29 @@ class CachedTMDbClient(TMDbClient):
 
         return movies
 
-    async def get_movie_cast(self, movie_id: int) -> List[CastMember]:
-        with Session(bind=self.engine) as session:
-            cached = get_cached_movie_cast(session, movie_id)
-            if cached is not None and len(cached) > 0:
-                return [
-                    CastMember(
-                        id=credit.person.tmdb_id,
-                        name=credit.person.name,
-                        profile_path=credit.person.profile_path,
-                        popularity=credit.person.popularity,
-                        character=credit.character,
-                        order=credit.credit_order,
-                    )
-                    for credit in cached
-                ]
+    async def get_movie_cast(
+        self, movie_id: int, trust_cache: bool = True
+    ) -> List[CastMember]:
+        if trust_cache:
+            with Session(bind=self.engine) as session:
+                movie = session.get(MovieRecord, movie_id)
+                if movie is not None and movie.has_full_cast:
+                    cached = get_cached_movie_cast(session, movie_id)
+                    if cached:
+                        return [
+                            CastMember(
+                                id=credit.person.tmdb_id,
+                                name=credit.person.name,
+                                profile_path=credit.person.profile_path,
+                                popularity=credit.person.popularity,
+                                character=credit.character,
+                                order=credit.credit_order,
+                            )
+                            for credit in cached
+                        ]
 
-        # Cache miss — call the API
         cast = await super().get_movie_cast(movie_id)
 
-        # We need the movie record to store; fetch via search
         movie = await self.search_movie_by_id(movie_id)
         if movie is not None:
             with Session(bind=self.engine) as session:

--- a/art_graph/cinema_data_providers/cache/operations.py
+++ b/art_graph/cinema_data_providers/cache/operations.py
@@ -88,6 +88,7 @@ def store_person_movies(
         person.name,
         profile_path=person.profile_path,
         popularity=person.popularity,
+        has_full_filmography=True,
     )
     for movie in movies:
         upsert_movie(
@@ -117,6 +118,7 @@ def store_movie_cast(session: Session, movie: Movie, cast: List[CastMember]):
         release_date=movie.release_date,
         poster_path=movie.poster_path,
         popularity=movie.popularity,
+        has_full_cast=True,
     )
     for member in cast:
         upsert_person(

--- a/art_graph/cinema_data_providers/cache/orm_models.py
+++ b/art_graph/cinema_data_providers/cache/orm_models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Float, Date, ForeignKey
+from sqlalchemy import Boolean, Column, Integer, String, Float, Date, ForeignKey
 from sqlalchemy.orm import DeclarativeBase, relationship
 
 
@@ -13,6 +13,7 @@ class PersonRecord(Base):
     name = Column(String, nullable=False)
     profile_path = Column(String, nullable=True)
     popularity = Column(Float, default=0.0)
+    has_full_filmography = Column(Boolean, default=False, nullable=False)
 
     credits = relationship("CreditRecord", back_populates="person")
 
@@ -25,6 +26,7 @@ class MovieRecord(Base):
     release_date = Column(Date, nullable=True)
     poster_path = Column(String, nullable=True)
     popularity = Column(Float, default=0.0)
+    has_full_cast = Column(Boolean, default=False, nullable=False)
 
     credits = relationship("CreditRecord", back_populates="movie")
 

--- a/art_graph/tests/test_cache_orm.py
+++ b/art_graph/tests/test_cache_orm.py
@@ -30,7 +30,13 @@ class TestTableCreation:
         engine = in_memory_engine()
         inspector = sqlalchemy.inspect(engine)
         columns = {c["name"] for c in inspector.get_columns("person")}
-        assert columns == {"tmdb_id", "name", "profile_path", "popularity", "has_full_filmography"}
+        assert columns == {
+            "tmdb_id",
+            "name",
+            "profile_path",
+            "popularity",
+            "has_full_filmography",
+        }
 
     def test_movie_columns(self):
         engine = in_memory_engine()

--- a/art_graph/tests/test_cache_orm.py
+++ b/art_graph/tests/test_cache_orm.py
@@ -30,7 +30,7 @@ class TestTableCreation:
         engine = in_memory_engine()
         inspector = sqlalchemy.inspect(engine)
         columns = {c["name"] for c in inspector.get_columns("person")}
-        assert columns == {"tmdb_id", "name", "profile_path", "popularity"}
+        assert columns == {"tmdb_id", "name", "profile_path", "popularity", "has_full_filmography"}
 
     def test_movie_columns(self):
         engine = in_memory_engine()
@@ -42,6 +42,7 @@ class TestTableCreation:
             "release_date",
             "poster_path",
             "popularity",
+            "has_full_cast",
         }
 
     def test_credit_columns(self):

--- a/art_graph/tests/test_cached_client.py
+++ b/art_graph/tests/test_cached_client.py
@@ -115,13 +115,13 @@ class TestGetPersonMovies:
         ):
             await client.get_person_movies(6193)
 
-        # Second call should hit cache
+        # Second call with trust_cache=True should hit cache
         with patch.object(
             client.__class__.__bases__[0],
             "get_person_movies",
             new_callable=AsyncMock,
         ) as mock_api:
-            result = await client.get_person_movies(6193)
+            result = await client.get_person_movies(6193, trust_cache=True)
             mock_api.assert_not_called()
             assert len(result) == 2
             titles = {m.title for m in result}
@@ -150,9 +150,86 @@ class TestGetPersonMovies:
             "get_person_movies",
             new_callable=AsyncMock,
         ):
-            result = await client.get_person_movies(6193)
+            result = await client.get_person_movies(6193, trust_cache=True)
             assert result[0].title == "Inception"  # popularity 90
             assert result[1].title == "Titanic"  # popularity 85
+
+    @pytest.mark.asyncio
+    async def test_default_does_not_trust_cache(self, client):
+        """get_person_movies defaults to trust_cache=False, always hitting API."""
+        # Populate cache
+        with (
+            patch.object(
+                client.__class__.__bases__[0],
+                "get_person_movies",
+                new_callable=AsyncMock,
+                return_value=MOVIES,
+            ),
+            patch.object(
+                client,
+                "get_person_details",
+                new_callable=AsyncMock,
+                return_value=PERSON,
+            ),
+        ):
+            await client.get_person_movies(6193)
+
+        # Default call (trust_cache=False) should still hit API
+        with (
+            patch.object(
+                client.__class__.__bases__[0],
+                "get_person_movies",
+                new_callable=AsyncMock,
+                return_value=MOVIES,
+            ) as mock_api,
+            patch.object(
+                client,
+                "get_person_details",
+                new_callable=AsyncMock,
+                return_value=PERSON,
+            ),
+        ):
+            await client.get_person_movies(6193)
+            mock_api.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_incidental_person_not_trusted(self, client):
+        """A person added via store_movie_cast should not be a cache hit."""
+        # Store a movie cast — this creates person records incidentally
+        with (
+            patch.object(
+                client.__class__.__bases__[0],
+                "get_movie_cast",
+                new_callable=AsyncMock,
+                return_value=CAST,
+            ),
+            patch.object(
+                client,
+                "search_movie_by_id",
+                new_callable=AsyncMock,
+                return_value=MOVIE,
+            ),
+        ):
+            await client.get_movie_cast(27205)
+
+        # Asking for person movies with trust_cache=True should still miss,
+        # because has_full_filmography is False
+        with (
+            patch.object(
+                client.__class__.__bases__[0],
+                "get_person_movies",
+                new_callable=AsyncMock,
+                return_value=MOVIES,
+            ) as mock_api,
+            patch.object(
+                client,
+                "get_person_details",
+                new_callable=AsyncMock,
+                return_value=PERSON,
+            ),
+        ):
+            await client.get_person_movies(6193, trust_cache=True)
+            mock_api.assert_called_once()
 
 
 class TestGetMovieCast:
@@ -206,3 +283,79 @@ class TestGetMovieCast:
             assert len(result) == 2
             names = {c.name for c in result}
             assert names == {"Leonardo DiCaprio", "Joseph Gordon-Levitt"}
+
+    @pytest.mark.asyncio
+    async def test_trust_cache_false_skips_cache(self, client):
+        """get_movie_cast with trust_cache=False always hits API."""
+        # Populate cache
+        with (
+            patch.object(
+                client.__class__.__bases__[0],
+                "get_movie_cast",
+                new_callable=AsyncMock,
+                return_value=CAST,
+            ),
+            patch.object(
+                client,
+                "search_movie_by_id",
+                new_callable=AsyncMock,
+                return_value=MOVIE,
+            ),
+        ):
+            await client.get_movie_cast(27205)
+
+        # Call with trust_cache=False should still hit API
+        with (
+            patch.object(
+                client.__class__.__bases__[0],
+                "get_movie_cast",
+                new_callable=AsyncMock,
+                return_value=CAST,
+            ) as mock_api,
+            patch.object(
+                client,
+                "search_movie_by_id",
+                new_callable=AsyncMock,
+                return_value=MOVIE,
+            ),
+        ):
+            await client.get_movie_cast(27205, trust_cache=False)
+            mock_api.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_incidental_movie_not_trusted(self, client):
+        """A movie added via store_person_movies should not be a cast cache hit."""
+        # Store a person's filmography — this creates movie records incidentally
+        with (
+            patch.object(
+                client.__class__.__bases__[0],
+                "get_person_movies",
+                new_callable=AsyncMock,
+                return_value=MOVIES,
+            ),
+            patch.object(
+                client,
+                "get_person_details",
+                new_callable=AsyncMock,
+                return_value=PERSON,
+            ),
+        ):
+            await client.get_person_movies(6193)
+
+        # Asking for movie cast should miss — has_full_cast is False
+        with (
+            patch.object(
+                client.__class__.__bases__[0],
+                "get_movie_cast",
+                new_callable=AsyncMock,
+                return_value=CAST,
+            ) as mock_api,
+            patch.object(
+                client,
+                "search_movie_by_id",
+                new_callable=AsyncMock,
+                return_value=MOVIE,
+            ),
+        ):
+            await client.get_movie_cast(27205)
+            mock_api.assert_called_once()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "art_graph"
-version = "0.2.4"
+version = "0.2.5"
 description = "Tools for creating and analyzing art graphs"
 authors = ["Reuben Brasher <rkbrasher@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
  - Add `has_full_filmography` flag to `PersonRecord` and `has_full_cast` flag to
  `MovieRecord`                                                                     
  - `store_person_movies` sets `has_full_filmography=True`; `store_movie_cast` sets 
  `has_full_cast=True`                                                              
  - Incidental records (e.g. a person added as a cast member, or a movie added as
  part of a filmography) do not set these flags                                     
  - Add `trust_cache` parameter to `CachedTMDbClient.get_person_movies` (default    
  `False`) and `get_movie_cast` (default `True`)
  - When `trust_cache=True`, cached data is only used if the corresponding full-data
   flag is set                                
  - When `trust_cache=False`, the API is always called and the cache is refreshed   
  - Bump version to `0.2.5`                   
                                                                                    
  ## Motivation                           
                                                                                    
  Movie casts are essentially immutable — once fetched, they can be trusted         
  indefinitely. Actor filmographies grow over time as actors take new roles.        
  Previously, the cache could not distinguish between "we fetched this actor's full 
  filmography" and "we know about this actor because they appeared in a movie cast  
  lookup." This caused false cache hits with incomplete data, which broke downstream
   consumers (cinema_game's puzzle generator dead-ended on every random walk because
   it was getting 1-2 movies instead of 20).

  The defaults reflect this asymmetry:
  - **Movie cast**: trust by default (`trust_cache=True`) — casts don't change
  - **Actor filmography**: distrust by default (`trust_cache=False`) — filmographies
   grow                                       
                                                                                    
  Callers can override per-call based on context (e.g. move validation can use      
  cached data to confirm a guess before falling back to the API).                   
                                                                                    
  ## Test plan                                                                      
                  
  - [ ] All 85 tests pass (`make test`)                                             
  - [ ] `test_incidental_person_not_trusted` — person from cast lookup is not a
  filmography cache hit                       
  - [ ] `test_incidental_movie_not_trusted` — movie from filmography lookup is not a
   cast cache hit
  - [ ] `test_default_does_not_trust_cache` — `get_person_movies` always hits API by
   default                                    
  - [ ] `test_trust_cache_false_skips_cache` — `get_movie_cast` with                
  `trust_cache=False` bypasses cache          